### PR TITLE
Fix game won when clicking last mine

### DIFF
--- a/mysweeper.js
+++ b/mysweeper.js
@@ -133,14 +133,14 @@ var clickCell = function() {
     this.classList.add('visible');
     hidden = hidden - 1;
 
-    if (hidden === mines_count) {
-        document.getElementById('text').innerHTML = "You Won!";
+    if (this.classList.contains('mine')) {
+        document.getElementById('text').innerHTML = "Game Over";
         endGame();
         return;
     }
 
-    if (this.classList.contains('mine')) {
-        document.getElementById('text').innerHTML = "Game Over";
+    if (hidden === mines_count) {
+        document.getElementById('text').innerHTML = "You Won!";
         endGame();
         return;
     }


### PR DESCRIPTION
Due to the order of execution, the test of amount of hidden cells was done before the check for clicking a mine. So when clicking a mine when there are only 2 cells remaining, it will show as game won